### PR TITLE
Harry/3349 fixes

### DIFF
--- a/u_common.go
+++ b/u_common.go
@@ -20,7 +20,7 @@ const (
 	utlsExtensionExtendedMasterSecret uint16 = 23 // https://tools.ietf.org/html/rfc7627
 
 	// extensions with 'fake' prefix break connection, if server echoes them back
-	fakeExtensionChannelID uint16 = 30032 // not IANA assigned
+	fakeExtensionChannelID uint16 = 30031 // not IANA assigned
 
 	fakeCertCompressionAlgs uint16 = 0x001b
 	fakeRecordSizeLimit     uint16 = 0x001c

--- a/u_common.go
+++ b/u_common.go
@@ -21,7 +21,8 @@ const (
 
 	// extensions with 'fake' prefix break connection, if server echoes them back
 	fakeExtensionTokenBinding uint16 = 24
-	fakeExtensionChannelID    uint16 = 30031 // not IANA assigned
+	fakeExtensionChannelIDOld uint16 = 30031 // not IANA assigned
+	fakeExtensionChannelID    uint16 = 30032 // not IANA assigned
 	fakeCertCompressionAlgs   uint16 = 0x001b
 	fakeRecordSizeLimit       uint16 = 0x001c
 )

--- a/u_common.go
+++ b/u_common.go
@@ -20,10 +20,10 @@ const (
 	utlsExtensionExtendedMasterSecret uint16 = 23 // https://tools.ietf.org/html/rfc7627
 
 	// extensions with 'fake' prefix break connection, if server echoes them back
-	fakeExtensionChannelID uint16 = 30031 // not IANA assigned
-
-	fakeCertCompressionAlgs uint16 = 0x001b
-	fakeRecordSizeLimit     uint16 = 0x001c
+	fakeExtensionTokenBinding uint16 = 24
+	fakeExtensionChannelID    uint16 = 30031 // not IANA assigned
+	fakeCertCompressionAlgs   uint16 = 0x001b
+	fakeRecordSizeLimit       uint16 = 0x001c
 )
 
 const (

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -1180,8 +1180,21 @@ func FingerprintClientHello(data []byte) (*ClientHelloSpec, error) {
 		case utlsExtensionPadding:
 			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &UtlsPaddingExtension{GetPaddingLen: BoringPaddingStyle})
 
-		case fakeExtensionChannelID, fakeExtensionChannelIDOld, fakeCertCompressionAlgs,
-			fakeRecordSizeLimit, fakeExtensionTokenBinding:
+		case fakeExtensionChannelID:
+			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &FakeChannelIDExtension{})
+
+		case fakeExtensionChannelIDOld:
+			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &FakeChannelIDExtension{true})
+
+		case fakeExtensionTokenBinding:
+			var majorVersion, minorVersion uint8
+			if !extData.ReadUint8(&majorVersion) || !extData.ReadUint8(&minorVersion) {
+				return nil, errors.New("unable to read token binding extension data")
+			}
+			tokenBindingExt := &FakeTokenBindingExtension{majorVersion, minorVersion}
+			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, tokenBindingExt)
+
+		case fakeCertCompressionAlgs, fakeRecordSizeLimit:
 			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &GenericExtension{extension, extData})
 
 		case extensionPreSharedKey:

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -1187,12 +1187,15 @@ func FingerprintClientHello(data []byte) (*ClientHelloSpec, error) {
 			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &FakeChannelIDExtension{true})
 
 		case fakeExtensionTokenBinding:
-			var majorVersion, minorVersion uint8
-			if !extData.ReadUint8(&majorVersion) || !extData.ReadUint8(&minorVersion) {
+			var tokenBindingExt FakeTokenBindingExtension
+			var keyParameters cryptobyte.String
+			if !extData.ReadUint8(&tokenBindingExt.MajorVersion) ||
+				!extData.ReadUint8(&tokenBindingExt.MinorVersion) ||
+				!extData.ReadUint8LengthPrefixed(&keyParameters) {
 				return nil, errors.New("unable to read token binding extension data")
 			}
-			tokenBindingExt := &FakeTokenBindingExtension{majorVersion, minorVersion}
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, tokenBindingExt)
+			tokenBindingExt.KeyParameters = keyParameters
+			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &tokenBindingExt)
 
 		case fakeCertCompressionAlgs, fakeRecordSizeLimit:
 			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &GenericExtension{extension, extData})

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -1180,7 +1180,8 @@ func FingerprintClientHello(data []byte) (*ClientHelloSpec, error) {
 		case utlsExtensionPadding:
 			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &UtlsPaddingExtension{GetPaddingLen: BoringPaddingStyle})
 
-		case fakeExtensionChannelID, fakeCertCompressionAlgs, fakeRecordSizeLimit, fakeExtensionTokenBinding:
+		case fakeExtensionChannelID, fakeExtensionChannelIDOld, fakeCertCompressionAlgs,
+			fakeRecordSizeLimit, fakeExtensionTokenBinding:
 			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &GenericExtension{extension, extData})
 
 		case extensionPreSharedKey:

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -1180,7 +1180,7 @@ func FingerprintClientHello(data []byte) (*ClientHelloSpec, error) {
 		case utlsExtensionPadding:
 			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &UtlsPaddingExtension{GetPaddingLen: BoringPaddingStyle})
 
-		case fakeExtensionChannelID, fakeCertCompressionAlgs, fakeRecordSizeLimit:
+		case fakeExtensionChannelID, fakeCertCompressionAlgs, fakeRecordSizeLimit, fakeExtensionTokenBinding:
 			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &GenericExtension{extension, extData})
 
 		case extensionPreSharedKey:

--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -675,6 +675,8 @@ FAKE EXTENSIONS
 */
 
 type FakeChannelIDExtension struct {
+	// The extension ID changed from 30031 to 30032. Set to true to use the old extension ID.
+	oldExtensionID bool
 }
 
 func (e *FakeChannelIDExtension) writeToUConn(uc *UConn) error {
@@ -689,9 +691,13 @@ func (e *FakeChannelIDExtension) Read(b []byte) (int, error) {
 	if len(b) < e.Len() {
 		return 0, io.ErrShortBuffer
 	}
+	extensionID := fakeExtensionChannelID
+	if e.oldExtensionID {
+		extensionID = fakeExtensionChannelIDOld
+	}
 	// https://tools.ietf.org/html/draft-balfanz-tls-channelid-00
-	b[0] = byte(fakeExtensionChannelID >> 8)
-	b[1] = byte(fakeExtensionChannelID & 0xff)
+	b[0] = byte(extensionID >> 8)
+	b[1] = byte(extensionID & 0xff)
 	// The length is 0
 	return e.Len(), io.EOF
 }

--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -676,7 +676,7 @@ FAKE EXTENSIONS
 
 type FakeChannelIDExtension struct {
 	// The extension ID changed from 30031 to 30032. Set to true to use the old extension ID.
-	oldExtensionID bool
+	OldExtensionID bool
 }
 
 func (e *FakeChannelIDExtension) writeToUConn(uc *UConn) error {
@@ -692,7 +692,7 @@ func (e *FakeChannelIDExtension) Read(b []byte) (int, error) {
 		return 0, io.ErrShortBuffer
 	}
 	extensionID := fakeExtensionChannelID
-	if e.oldExtensionID {
+	if e.OldExtensionID {
 		extensionID = fakeExtensionChannelIDOld
 	}
 	// https://tools.ietf.org/html/draft-balfanz-tls-channelid-00
@@ -771,7 +771,7 @@ func (e *FakeRecordSizeLimitExtension) Read(b []byte) (int, error) {
 // https://tools.ietf.org/html/rfc8472#section-2
 
 type FakeTokenBindingExtension struct {
-	major, minor uint8
+	Major, Minor uint8
 }
 
 func (e *FakeTokenBindingExtension) writeToUConn(uc *UConn) error {
@@ -786,7 +786,7 @@ func (e *FakeTokenBindingExtension) Read(b []byte) (int, error) {
 	if len(b) < e.Len() {
 		return 0, io.ErrShortBuffer
 	}
-	b[0] = e.major
-	b[1] = e.minor
+	b[0] = e.Major
+	b[1] = e.Minor
 	return 0, io.EOF
 }

--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -761,3 +761,26 @@ func (e *FakeRecordSizeLimitExtension) Read(b []byte) (int, error) {
 	b[5] = byte(e.Limit & 0xff)
 	return e.Len(), io.EOF
 }
+
+// https://tools.ietf.org/html/rfc8472#section-2
+
+type FakeTokenBindingExtension struct {
+	major, minor uint8
+}
+
+func (e *FakeTokenBindingExtension) writeToUConn(uc *UConn) error {
+	return nil
+}
+
+func (e *FakeTokenBindingExtension) Len() int {
+	return 2
+}
+
+func (e *FakeTokenBindingExtension) Read(b []byte) (int, error) {
+	if len(b) < e.Len() {
+		return 0, io.ErrShortBuffer
+	}
+	b[0] = e.major
+	b[1] = e.minor
+	return 0, nil
+}

--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -782,5 +782,5 @@ func (e *FakeTokenBindingExtension) Read(b []byte) (int, error) {
 	}
 	b[0] = e.major
 	b[1] = e.minor
-	return 0, nil
+	return 0, io.EOF
 }

--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -771,7 +771,8 @@ func (e *FakeRecordSizeLimitExtension) Read(b []byte) (int, error) {
 // https://tools.ietf.org/html/rfc8472#section-2
 
 type FakeTokenBindingExtension struct {
-	Major, Minor uint8
+	MajorVersion, MinorVersion uint8
+	KeyParameters              []uint8
 }
 
 func (e *FakeTokenBindingExtension) writeToUConn(uc *UConn) error {
@@ -779,14 +780,17 @@ func (e *FakeTokenBindingExtension) writeToUConn(uc *UConn) error {
 }
 
 func (e *FakeTokenBindingExtension) Len() int {
-	return 2
+	return 2 + len(e.KeyParameters)
 }
 
 func (e *FakeTokenBindingExtension) Read(b []byte) (int, error) {
 	if len(b) < e.Len() {
 		return 0, io.ErrShortBuffer
 	}
-	b[0] = e.Major
-	b[1] = e.Minor
+	b[0] = e.MajorVersion
+	b[1] = e.MinorVersion
+	if len(e.KeyParameters) > 0 {
+		copy(b[2:], e.KeyParameters)
+	}
 	return 0, io.EOF
 }


### PR DESCRIPTION
The channel ID and token binding extensions appear in ClientHellos sent by Explorer and 360 Browser respectively.  These changes were necessary to fingerprint those hellos.

The channel ID extension was already implemented, but appeared to be using the wrong extension ID.  It was off by 1, so maybe it was a typo.  In any case, that fix seems to have upset the tests.  I can look into fixing them later today.