### PR TITLE
Add fake ALPS extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
- - "1.11.x"
+ - "1.16.x"
 
 sudo: required
 dist: trusty

--- a/u_common.go
+++ b/u_common.go
@@ -23,8 +23,10 @@ const (
 	fakeExtensionTokenBinding uint16 = 24
 	fakeExtensionChannelIDOld uint16 = 30031 // not IANA assigned
 	fakeExtensionChannelID    uint16 = 30032 // not IANA assigned
-	fakeCertCompressionAlgs   uint16 = 0x001b
-	fakeRecordSizeLimit       uint16 = 0x001c
+	fakeExtensionALPS         uint16 = 17513 // not IANA assigned
+
+	fakeCertCompressionAlgs uint16 = 0x001b
+	fakeRecordSizeLimit     uint16 = 0x001c
 )
 
 const (


### PR DESCRIPTION
This extension has been added to BoringSSL and is now being sent by Chrome (and
presumably other Chromium-based browsers).

See:
https://boringssl.googlesource.com/boringssl/+/51607f1fe11202f2876ec26486ffbef3cbbf0f35
https://datatracker.ietf.org/doc/html/draft-vvv-tls-alps

We don't actually implement anything sent in the ALPS extension.  In theory, we could run into issues sending ALPS data if the server responds to it.  However, I've tested against a number of sites and haven't seen too many problems.  I've also tested against our own TLS listener used by our HTTPS proxies without issue.