### PR TITLE
Add fake support for the delegated credentials extension

### DIFF
--- a/u_common.go
+++ b/u_common.go
@@ -23,10 +23,11 @@ const (
 	utlsExtensionCompressCertificate uint16 = 27
 
 	// extensions with 'fake' prefix break connection, if server echoes them back
-	fakeExtensionTokenBinding uint16 = 24
-	fakeExtensionChannelIDOld uint16 = 30031 // not IANA assigned
-	fakeExtensionChannelID    uint16 = 30032 // not IANA assigned
-	fakeExtensionALPS         uint16 = 17513 // not IANA assigned
+	fakeExtensionTokenBinding         uint16 = 24
+	fakeExtensionChannelIDOld         uint16 = 30031 // not IANA assigned
+	fakeExtensionChannelID            uint16 = 30032 // not IANA assigned
+	fakeExtensionALPS                 uint16 = 17513 // not IANA assigned
+	fakeExtensionDelegatedCredentials uint16 = 34
 
 	fakeRecordSizeLimit uint16 = 0x001c
 


### PR DESCRIPTION
This extension is being sent by Firefox and possibly other browsers. At the time of this writing, this extension has been submitted as an Internet-Draft, the latest of which can be found here:

https://datatracker.ietf.org/doc/html/draft-ietf-tls-subcerts-15