### PR TITLE
Bug fix: fix cert decompression via zlib by ignoring EOF

### DIFF
--- a/handshake_client_tls13.go
+++ b/handshake_client_tls13.go
@@ -772,7 +772,7 @@ func (hs *clientHandshakeStateTLS13) decompressCert(m compressedCertificateMsg) 
 	rawMsg[3] = uint8(m.uncompressedLength)
 
 	n, err := decompressed.Read(rawMsg[4:])
-	if err != nil {
+	if err != nil && !errors.Is(err, io.EOF) {
 		c.sendAlert(alertBadCertificate)
 		return nil, err
 	}


### PR DESCRIPTION
An io.Reader is allowed (but not required) to return io.EOF upon reading the last byte of the stream, even if no subsequent bytes were requested. We later check that we read the expected number of bytes, so we can safely ignore EOF errors returned by the decompression readers.

Back-port of https://github.com/refraction-networking/utls/pull/206